### PR TITLE
Security Contexts

### DIFF
--- a/src/embeddable.com/presets/security-contexts.sc.yml
+++ b/src/embeddable.com/presets/security-contexts.sc.yml
@@ -1,27 +1,17 @@
-- name: Individual1564
+- name: Hedgehogs (Staging)
+  environment: staging-eu
   securityContext:
-    GroupID: Individual1564
-    canSeeOwnSchool: true
-    CanReadNames: true
-    SchoolID: [1564]
-    RestrictedToOneSchool: false
-  environment: default
+    accountId: 371
+    language: en_GB
 
-- name: TTCT
+- name: "Jackson's Art Prize (UAT)"
+  environment: uat-eu
   securityContext:
-    GroupID: Group2
-    canSeeOwnSchool: true
-    CanReadNames: true
-    SchoolID: [256, 257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 828]
-    RestrictedToOneSchool: false
-  environment: default
+    accountId: 244
+    language: en_GB
 
-- name: dev_group
+- name: "Configure (Production)"
+  environment: production-eu
   securityContext:
-    GroupID: dev_global_dataset
-  environment: default
-
-- name: dev_group_2
-  securityContext:
-    GroupID: dev_global_dataset_2
-  environment: default
+    accountId: 637
+    language: en_GB


### PR DESCRIPTION
Currently, the security contexts are only in the staging branch and not yet in the main branch. This is because I use the staging branch for making features available for QA review even if the PR isn’t merged to main yet (similar to the workflow in AF4 and our other repos)

This task is to replace the default Embeddable security contexts with our own in the main branch as well